### PR TITLE
trustless version of pools

### DIFF
--- a/dapps/archived/Cargo.toml
+++ b/dapps/archived/Cargo.toml
@@ -3,5 +3,6 @@ members = [
     "hound",
     "chihuahua",
     "basset",
-    "old_dusk"
+    "old_dusk",
+    "pools"
 ]

--- a/dapps/archived/pools/Cargo.toml
+++ b/dapps/archived/pools/Cargo.toml
@@ -5,17 +5,17 @@ edition = "2024"
 
 [[bin]]
 name = "pools"
-path = "../../quizzes/src/quiz10/c_local_pools/src/main.rs"
+path = "../../../quizzes/src/quiz10/b_pools/src/main.rs"
 
 [dependencies]
 chrono = "0.4.38"
 
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 
-book = { path = "../../../crypto-n-rust/src/libs/book" }
+book = { path = "../../../../crypto-n-rust/src/libs/book" }
 
-quizzes = { path = "../../quizzes" }
-libs = { path = "../../libs" }
+quizzes = { path = "../../../quizzes" }
+libs = { path = "../../../libs" }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tarpaulin_include)'] }

--- a/dapps/pools/README.md
+++ b/dapps/pools/README.md
@@ -1,0 +1,39 @@
+# `pools`
+
+`$ pools <auth> <date>`
+
+where:
+
+* `<auth>` is the protocol that has pivot pools, e.g. `pivot`
+* `<date>` is today's date, e.g. `$LE_DATE`
+
+> n.b.: `PIVOT_DATA_DIR` must be set in the environment
+
+## Sample run
+
+`$ pools pivot $LE_DATE`
+
+```Javascript
+const poolAssets = {
+   generated: '2026-04-29',
+   assets: [
+      [ 'AVAX', 'UNDEAD' ],
+      [ 'BTC', 'UNDEAD' ],
+      [ 'UNDEAD', 'USDC' ],
+      [ 'ETH', 'UNDEAD' ],
+      [ 'BTC', 'AVAX' ],
+      [ 'BTC', 'ETH' ],
+      [ 'BTC', 'USDC' ]
+   ]
+};
+```
+
+* [src](mod.rs)
+
+-----
+
+# Revision History
+
+* 2.01, 2026-04-29: trustless version, no authentication needed
+* 1.00, 2026-02-09: first version, reads pivot pools from github
+

--- a/quizzes/src/quiz10/c_local_pools/Cargo.toml
+++ b/quizzes/src/quiz10/c_local_pools/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "c_local_pools"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]

--- a/quizzes/src/quiz10/c_local_pools/README.md
+++ b/quizzes/src/quiz10/c_local_pools/README.md
@@ -1,0 +1,22 @@
+# `c_local_pools`
+
+How do I run `pools` locally?
+
+## Context
+
+`pools` used to query git to get the active pools on the protocol. I find this
+gives `pools` too much access to the repository, no matter how careful one is.
+
+## Locally
+
+Therefore, revise `pools` to read the active pools from the local 
+directory-system, and have git manage what is visibly local to `pools`.
+
+Security-issue solved.
+
+## New `pools`
+
+`$ pools <dir>`
+
+* where `<dir>` is the directory where the active pools reside.
+

--- a/quizzes/src/quiz10/c_local_pools/mod.rs
+++ b/quizzes/src/quiz10/c_local_pools/mod.rs
@@ -1,0 +1,117 @@
+use book::err_utils::ErrStr;
+
+fn app_name() -> String { "pools".to_string() }
+fn version() -> String { "2.01".to_string() }
+
+fn usage() -> ErrStr<()> {
+   println!("
+Usage:
+      
+$ {} <auth> <date>
+      
+Given <auth> access and <date>, {} prints a Javascript object of pool assets.
+", app_name(), app_name());
+   Err("Need <auth> and <date> arguments".to_string()) 
+}     
+
+mod pools_impl {
+   use super::*;
+   use chrono::NaiveDate;
+
+   use book::{
+      file_utils::{dirs_files,file_names},
+      list_utils::filter_map_or,
+      string_utils::str2strf,
+      utils::get_env
+   };
+   use libs::{ paths::pivot_pool_from_file, types::util::Pool };
+
+   pub async fn print_pools_as_js(auth: &str, date: NaiveDate) -> ErrStr<()> {
+      let a = pools(auth).await?;
+      let js = to_js(date, a);
+      println!("{js}\n");
+      Ok(())
+   }
+
+   async fn pools(auth: &str) -> ErrStr<Vec<Pool>> {
+      let aut = auth.to_uppercase();
+      let path = get_env(&format!("{aut}_DATA_DIR"))?;
+      let open_dir = format!("{path}/pivots/open/raw");
+      let (_dirs, opens_filebufs) = dirs_files(&open_dir);
+      let opens = file_names(&opens_filebufs);
+      filter_map_or(str2strf(&pivot_pool_from_file), opens)
+   }
+
+   fn to_js(dt: NaiveDate, pools: Vec<Pool>) -> String {
+      fn pool2pool(p: Pool) -> String {
+         let (a, b) = p;
+         format!("[ '{}', '{}' ]", a.to_uppercase(), b.to_uppercase())
+      }
+      let assets: Vec<String> = pools.into_iter().map(pool2pool).collect();
+      format!(" 
+const poolAssets = {{
+   generated: '{dt}',
+   assets: [
+      {}
+   ]
+}};
+",  assets.join(",\n      "))
+   }
+
+   // ----- TESTS -------------------------------------------------------
+   #[cfg(not(tarpaulin_include))]
+   #[cfg(test)]
+   mod tests {
+      use std::collections::HashSet;
+      use super::*;
+      use book::date_utils::today;
+      use libs::types::util::mk_pool;
+
+      #[tokio::test] async fn fail_print_pools_as_js() {
+         assert!(print_pools_as_js("asdf", today()).await.is_err());
+      }
+
+      #[tokio::test] async fn test_print_pools_as_js_ok() {
+         assert!(print_pools_as_js("pivot", today()).await.is_ok());
+      }
+
+      #[tokio::test] async fn test_pools_has_btc_eth() -> ErrStr<()> {
+         let pivot_pools = pools("pivot").await?;
+         let pp: HashSet<Pool> = pivot_pools.into_iter().collect();
+         assert!(pp.contains(&mk_pool("btc", "eth")));
+         Ok(())
+      }
+   }
+}
+
+#[cfg(not(tarpaulin_include))]
+pub mod functional_tests {
+   use super::*;
+   use super::pools_impl::print_pools_as_js;
+   use book::{
+      date_utils::{parse_date,today},
+      err_utils::ErrStr,
+      test_utils::preamble,
+      utils::get_args
+   };
+
+   pub async fn runoff_with_args() -> ErrStr<()> {
+      println!("\n// created by: {}, version: {}\n", app_name(), version());
+
+      let args = get_args();
+      if let [auth, dt] = args.as_slice() {
+         let date = parse_date(&dt)?;
+         print_pools_as_js(&auth, date).await
+      } else {
+         usage()
+      }
+   }
+
+   pub async fn runoff() -> ErrStr<usize> {
+      preamble("quiz10::c_local_pools");
+      let date = today();
+      let _ = print_pools_as_js("pivot", date).await?;
+      Ok(1)
+   }
+}
+

--- a/quizzes/src/quiz10/c_local_pools/src/main.rs
+++ b/quizzes/src/quiz10/c_local_pools/src/main.rs
@@ -1,0 +1,8 @@
+use book::err_utils::ErrStr;
+
+use quizzes::quiz10::c_local_pools::functional_tests::runoff_with_args;
+
+#[cfg(not(tarpaulin_include))]
+#[tokio::main]
+async fn main() -> ErrStr<()> { runoff_with_args().await }
+

--- a/quizzes/src/quiz10/mod.rs
+++ b/quizzes/src/quiz10/mod.rs
@@ -1,12 +1,14 @@
 
 pub mod a_files;
 pub mod b_pools;
+pub mod c_local_pools;
 
 #[cfg(not(tarpaulin_include))]
 pub mod functional_tests {
    use super::{
       a_files::functional_tests::runoff as a,
-      b_pools::functional_tests::runoff as b
+      b_pools::functional_tests::runoff as b,
+      c_local_pools::functional_tests::runoff as c
    };
 
    use book::err_utils::ErrStr;
@@ -15,6 +17,7 @@ pub mod functional_tests {
       println!("\nquiz10 functional tests\n");
       let n1 = a()?;
       let n2 = b().await?;
-      Ok(n1 + n2)
+      let n3 = c().await?;
+      Ok(n1 + n2 + n3)
    }
 }


### PR DESCRIPTION
Have `pools` read from the local directory instead of getting pivot pool information from github with a PAT.