### PR TITLE
Protocol issue 060 dapps closer

### DIFF
--- a/dapps/wyrd/Cargo.toml
+++ b/dapps/wyrd/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 
 [[bin]]
 name = "wyrd"
-path = "../../quizzes/src/quiz08/b_urie/src/main.rs"
+path = "../../quizzes/src/quiz08/b_wyrd/src/main.rs"
 
 [dependencies]
 tokio = { version = "1.51.2", features = ["macros", "rt-multi-thread"] }

--- a/quizzes/src/quiz08/b_wyrd/Cargo.toml
+++ b/quizzes/src/quiz08/b_wyrd/Cargo.toml
@@ -13,3 +13,4 @@ quizzes = { path = "../../../" }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tarpaulin_include)'] }
+


### PR DESCRIPTION
# Problem 
`Cargo.toml` was reading as `urie`, not `wyrd` ... that has been changed